### PR TITLE
DEVOP-1209: Add service account for kubernetes-external-secrets

### DIFF
--- a/modules/eks-iam/kubernetes-external-secrets.tf
+++ b/modules/eks-iam/kubernetes-external-secrets.tf
@@ -1,0 +1,47 @@
+# IAM permissions for the kubernetes-external-secrets operator, mainly to read credentials from Secrets Manager
+
+module "kubernetes-external-secrets" {
+  source                    = "./modules/service-account"
+
+  service_account_name      = "kubernetes-external-secrets"
+  service_account_namespace = "kubernetes-external-secrets"
+  aws_iam_policy_document = join("", data.aws_iam_policy_document.kubernetes-external-secrets.*.json)
+
+  cluster_context = local.cluster_context
+  context         = module.this.context
+}
+
+data "aws_iam_policy_document" "kubernetes-external-secrets" {
+  statement {
+    sid = "ReadSecrets"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecretVersionIds"
+    ]
+
+    effect = "Allow"
+    resources = ["*"]
+
+    # Limit to secrets tagged for argoCD
+    condition {
+      test     = "Null"
+      values   = ["false"]
+      variable = "secretsmanager:ResourceTag/argocd:credentials:type"
+    }
+
+  }
+
+  statement {
+    sid = "ListSecrets"
+
+    actions = [
+      "secretsmanager:ListSecrets"
+    ]
+
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}

--- a/modules/eks-iam/main.tf
+++ b/modules/eks-iam/main.tf
@@ -22,13 +22,15 @@ locals {
   # Unfortunately, we cannot create a map piece by piece, so
   # every service account module has to register in this output_map
   output_map = {
-    alb-controller           = module.alb-controller.outputs
-    autoscaler               = module.autoscaler.outputs
-    cert-manager             = module.cert-manager.outputs
-    external-dns             = module.external-dns.outputs
-    github-action-runner     = module.github-action-runner.outputs
-    jenkins-master           = module.jenkins-master,
-    jenkins-worker           = module.jenkins-worker,
+    alb-controller              = module.alb-controller.outputs
+    autoscaler                  = module.autoscaler.outputs
+    cert-manager                = module.cert-manager.outputs
+    external-dns                = module.external-dns.outputs
+    github-action-runner        = module.github-action-runner.outputs
+    jenkins-master              = module.jenkins-master,
+    jenkins-worker              = module.jenkins-worker,
+    kubernetes-external-secrets = module.kubernetes-external-secrets
+
   }
 
   cluster_context = {


### PR DESCRIPTION
## what
* Add service account for kubernetes-external-secrets operator to allow it to read from secrets manager.

## why
* Because the kubernetes-external-secrets operator needs to be able to read secrets from the secrets manager in order to convert them into kubernetes secrets

## references
* https://github.com/external-secrets/kubernetes-external-secrets

