### PR TITLE
ELT-9568: Fix EKS failing after atmos upgrade

### DIFF
--- a/modules/eks/remote-state.tf
+++ b/modules/eks/remote-state.tf
@@ -1,20 +1,18 @@
 module "vpc" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.17.0"
+  version = "0.22.0"
 
   component               = "vpc"
-  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
 
 module "primary_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.17.0"
+  version = "0.22.0"
 
   component               = "iam-primary-roles"
   environment             = var.iam_roles_environment_name
-  stack_config_local_path = "../../../stacks"
   stage                   = var.iam_primary_roles_stage_name
 
   context = module.this.context
@@ -22,24 +20,22 @@ module "primary_roles" {
 
 module "delegated_roles" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.17.0"
+  version = "0.22.0"
 
   component               = "iam-delegated-roles"
   environment             = var.iam_roles_environment_name
-  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
 
 module "workers_role" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.17.0"
+  version = "0.22.0"
 
   component = "eks-workers"
   defaults = {
     workers_role_arn = null
   }
-  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }
@@ -49,13 +45,12 @@ module "workers_role" {
 # to it rather than overwrite it (specifically the aws-auth configMap)
 module "eks" {
   source  = "cloudposse/stack-config/yaml//modules/remote-state"
-  version = "0.17.0"
+  version = "0.22.0"
 
   component = "eks"
   defaults = {
     eks_managed_node_workers_role_arns = []
   }
-  stack_config_local_path = "../../../stacks"
 
   context = module.this.context
 }

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -32,7 +32,7 @@ terraform {
     }
     utils = {
       source  = "cloudposse/utils"
-      version = "~> 0.3"
+      version = "~> 0.17.14"
     }
   }
 }


### PR DESCRIPTION
This PR contains a fix for eks module failing after moving to golang based atmos. It requires the infra code to contain changes from this PR: https://github.com/Datameer-Inc/infrastructure/pull/365/commits